### PR TITLE
Only allow request handlers on member invokers (typescript only)

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -51,7 +51,7 @@ function createServer(spies: any) {
   const classAPI = makeClassInvoker(TestClass)
   router.get('/function', fnAPI('handle'))
   router.get('/class', classAPI('handle'))
-  router.get('/fail', fnAPI('not a method'))
+  router.get('/fail', fnAPI('not a method' as any))
   app.use(router)
 
   return new Promise((resolve, reject) => {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -5,7 +5,8 @@ import {
   HttpVerbs,
   getStateAndTarget,
   IStateAndTarget,
-  IAwilixControllerBuilder
+  IAwilixControllerBuilder,
+  ClassOrFunctionReturning
 } from 'awilix-router-core'
 import { makeInvoker } from './invokers'
 import { Router } from 'express'
@@ -83,7 +84,7 @@ function _registerController(
         methodCfg.paths,
         ...methodCfg.beforeMiddleware,
         /*tslint:disable-next-line*/
-        makeInvoker(target as any)(methodName),
+        makeInvoker(target as ClassOrFunctionReturning<any>)(methodName as any),
         ...methodCfg.afterMiddleware
       )
     })


### PR DESCRIPTION
As a commodity, I've added conditional typing for invoker member names so that they are constrained to only the members that are request handlers. No impact on the generated javascript.